### PR TITLE
fix order between chords

### DIFF
--- a/test/test_harte.py
+++ b/test/test_harte.py
@@ -26,7 +26,9 @@ def test_coverage(chord: str):
 
 
 @pytest.mark.parametrize("chord,intervals", 
-                         [("C:maj", ["P5", "M3"]),
+                         [("C", ["P5", "M3"]),
+                          ("A", ["P5", "M3"]),
+                          ("C:maj", ["P5", "M3"]),
                           ("C:min", ["P5", "m3"])])
 def test_interval_extraction(chord: str, intervals: List[str]):
     """
@@ -39,7 +41,7 @@ def test_interval_extraction(chord: str, intervals: List[str]):
     :type intervals: List[str]
     """
     chord = Harte(chord)
-    annotated_intervals = chord.annotateIntervals(inPlace=False, 
-                                                  returnList=True, 
+    annotated_intervals = chord.annotateIntervals(inPlace=False,
+                                                  returnList=True,
                                                   stripSpecifiers=False)
     assert set(intervals) == set(annotated_intervals)


### PR DESCRIPTION
Order between the components of a chord was not preserved due to the usage of `transposeNote` in `Harte.__init__`.

Solved by converting the implicit pitch of the note to explicit and iteratively transpose each chord component to be above the previous one.