### PR TITLE
Fix for sorting of chord degrees following parse

### DIFF
--- a/harte/harte.py
+++ b/harte/harte.py
@@ -72,8 +72,22 @@ class Harte(Chord):
             self._all_degrees.append('1')
             # sort the list and remove duplicates
             self._all_degrees = list(set(self._all_degrees))
+
+            # sort the list of degrees according to the degree number
+            def degree_to_sort_key(degree: str) -> float:
+                # extract number from degree
+                degree_number = int("".join([k for k in degree if k.isdigit()]))
+
+                # extract accidental from degree
+                if degree.startswith('b'):
+                    degree_number -= 0.49
+                elif degree.startswith('#'):
+                    degree_number += 0.49
+                
+                return degree_number
+
             self._all_degrees.sort(
-                key=lambda x: [k for k in x if k.isdigit()][0])
+                key=lambda x: degree_to_sort_key(x))
 
             # convert notes and interval to m21 primitives
             # note that when multiple flats are introduced (i.e. Cbb) music21

--- a/harte/harte.py
+++ b/harte/harte.py
@@ -75,6 +75,13 @@ class Harte(Chord):
 
             # sort the list of degrees according to the degree number
             def degree_to_sort_key(degree: str) -> float:
+                """
+                Utility function for ordering degrees of a chord
+                :param degree: a chord degree
+                :type defree: str
+                :return: a numerical value needed for ordering the degree
+                :rtype: float
+                """
                 # extract number from degree
                 degree_number = int("".join([k for k in degree if k.isdigit()]))
 

--- a/test/test_harte.py
+++ b/test/test_harte.py
@@ -53,3 +53,18 @@ def test_interval_extraction(chord: str, intervals: List[str]):
                                                   returnList=True,
                                                   stripSpecifiers=False)
     assert set(intervals) == set(annotated_intervals)
+
+@pytest.mark.parametrize("chord,pitches", [("F:(b3, 5, b7, 11)", ["F", "A-", "C", "E-", "B-"]),
+                                           ("F:(b3, 11, b7, 5)", ["F", "A-", "C", "E-", "B-"]),
+                                           ("F:maj7(#11)", ["F", "A", "C", "E", "B"])])
+def test_ordering_of_degrees(chord: str, pitches: List[str]):
+    """
+    Test that the parsed degrees are ordered correctly in the resulting m21 object.
+
+    :param chord: Input chord
+    :type chord: str
+    :param pitches: Pitches that should be part of the chord
+    :type pitches: List[str]
+    """
+    chord = Harte(chord)
+    assert [p.name for p in chord.pitches] == pitches


### PR DESCRIPTION
Sorting a chord with an 11th degree was producing a strange ordering due to the way that the degrees were being sorted. 

For example `F:(b3, 5, 7, 11)` was being created with the pitch order of `[F, Bb, Ab, C, Eb]`.

This PR addresses this and also makes the sorting of flattened and sharpened degrees consistent. Now the 11th should appear above the 9th as you would expect